### PR TITLE
serverVars undefined index hataları

### DIFF
--- a/System/Libs/Http/Request.php
+++ b/System/Libs/Http/Request.php
@@ -75,7 +75,7 @@ class Request
 		if (is_null($param))
 			return $this->serverVars;
 		else
-			return $this->serverVars[$param];
+			return (isset($this->serverVars[$param]) ? $this->serverVars[$param] : null);
 	}
 
 	/**


### PR DESCRIPTION
$_SERVER global değişkeninde bazen ister istemez undefined index hataları alıyoruz. Bu hatalar Constants.php ENV sabit değişkeni 'production' olarak değiştirilerek önüne geçilebilir. Fakat bazı işlemlere bu değişkenler doğrultusunda devam etmek gerektiği için undefined index hataları Whoops ile birleşince aşılmaz bir hal alıyor bundan sebeb bu tarz değişkenleri isset ile kontrol edip null yada false döndürürsek daha stabil olacağını var sayıyorum. Arz ederim :)