### PR TITLE
Validation::isValid()

### DIFF
--- a/System/Libs/Validation/Validation.php
+++ b/System/Libs/Validation/Validation.php
@@ -91,7 +91,6 @@ class Validation
 	public function isValid()
 	{
 		foreach ($this->rules as $key => $value) {
-
 			$rules = explode('|', $value);
 
 			if (in_array('nullable', $rules)) {
@@ -111,23 +110,23 @@ class Validation
 
                     if ($filter == 'matches') {
                     	if ($this->matches($this->data[$key], $this->data[$params]) === false)
-                    		$this->errors[] = lang('validation', $filter . '_error', ['%s' => $this->labels[$key], '%t' => $this->labels[$params]]);
+                    		$this->errors[$key] = lang('validation', $filter . '_error', ['%s' => $this->labels[$key], '%t' => $this->labels[$params]]);
                     } else {
                         if ($nullable === true) {
                             if ($this->nullable($this->data[$key]) === false && $this->$filter($this->data[$key], $params) === false)
-                                $this->errors[] = lang('validation', $filter . '_error', ['%s' => $this->labels[$key], '%t' => $params]);
+                                $this->errors[$key] = lang('validation', $filter . '_error', ['%s' => $this->labels[$key], '%t' => $params]);
                         } else {
                             if ($this->$filter($this->data[$key], $params) === false)
-                                $this->errors[] = lang('validation', $filter . '_error', ['%s' => $this->labels[$key], '%t' => $params]);
+                                $this->errors[$key] = lang('validation', $filter . '_error', ['%s' => $this->labels[$key], '%t' => $params]);
                         }
                     }
 				} else {
 				    if ($nullable === true) {
 				        if ($this->nullable($this->data[$key]) === false && $this->$rule($this->data[$key]) === false)
-				            $this->errors[] = lang('validation', $rule . '_error', $this->labels[$key]);
+				            $this->errors[$key] = lang('validation', $rule . '_error', $this->labels[$key]);
                     } else {
                         if ($this->$rule($this->data[$key]) === false)
-                            $this->errors[] = lang('validation', $rule . '_error', $this->labels[$key]);
+                            $this->errors[$key] = lang('validation', $rule . '_error', $this->labels[$key]);
                     }
 				}
 			}


### PR DESCRIPTION
Html tarafındaki boş inputları işaretlemek için isValid methodundaki  errors dizi değişkenin key değerlerini indis vermek yerine rule methodunun ilk parametresi olarak tanımladık.
Böylelikle ajax  ile json verisi aldığım zaman hangi input doğrulama kuralına uymuyorsa javascript ile kolaylıkla işaretliyorum.