### PR TITLE
Sql hatalarını tam olarak ne olduğunu anlamak

### DIFF
--- a/System/Libs/Database/DB.php
+++ b/System/Libs/Database/DB.php
@@ -105,6 +105,7 @@ class DB
 			$this->pdo->exec("SET NAMES '" . $this->config['db_charset'] . "' COLLATE '" . $this->config['db_collation'] . "'");
 			$this->pdo->exec("SET CHARACTER SET '" . $this->config['db_charset'] . "'");
 			$this->pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_OBJ);
+            $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 		}
 		catch(PDOException $e)
 		{


### PR DESCRIPTION
Bir sorguda hata olduğu zaman exception bize getall fonksiyonunu hata olarak gösteriyordu. Sorgudaki hatayı bulmayı sağladım sanırım.