### PR TITLE
Files tanımsız değişken hatası giderimi

### DIFF
--- a/System/Libs/Http/Request.php
+++ b/System/Libs/Http/Request.php
@@ -212,7 +212,7 @@ class Request
 		if (is_null($param))
 			return $this->filesVars;
 		else
-			return $this->filesVars[$param];
+			return $this->filesVars[$param] ?? null;
 	}
 
 	/**


### PR DESCRIPTION
Request::files('file') kullanımında file gelmezsa undefined index hatası veriyordu. Giderildi.